### PR TITLE
Drop support for end-of-life Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 ---
 language: python
 python:
-  - "2.7"
-  - "3.2"
+  - "3.5"
 
 sudo: false
 
 matrix:
   fast_finish: true
   allow_failures:
-    - python: "3.2"
+    - python: "3.5"
 
 script:
   - py.test

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     url='https://github.com/tomasbasham/ratelimit',
     license='MIT',
     packages=['ratelimit'],
+    python_requires='>= 3.5',
     install_requires=[],
     keywords=[
         'ratelimit',


### PR DESCRIPTION
Python versions below 3.5 are now considered end-of-life with 2.7 support being dropped on 1st January 2020 and 3.4 on 3rd March 2019.
(https://devguide.python.org/devcycle/#end-of-life-branches)